### PR TITLE
Replace `ctx.resolve_tools()` with `ctx.actions.run(tools = ..., ...)`

### DIFF
--- a/lib/private/run_binary.bzl
+++ b/lib/private/run_binary.bzl
@@ -68,7 +68,7 @@ Possible fixes:
     ctx.actions.run(
         outputs = outputs,
         inputs = inputs,
-        tools = ctx.attr.tools.files,
+        tools = ctx.attr.tools.files_to_run,
         toolchain = None,
         executable = ctx.executable.tool,
         arguments = [args],


### PR DESCRIPTION
ctx.resolve_tools() is slated for deprecation

Type of change
Refactor (a code change that neither fixes a bug or adds a new feature)

Test plan
Covered by existing test cases